### PR TITLE
Foreign keys check bug

### DIFF
--- a/lib/Helper.class.php
+++ b/lib/Helper.class.php
@@ -133,6 +133,7 @@ class Helper
     $db = self::getDbObject();
     $db->query("create database `{$config['db']}`");
     $tmpdb =  self::getDbObject($config);
+    $tmpdb->query("SET FOREIGN_KEY_CHECKS = 0");
     register_shutdown_function(function() use($config,$tmpdb)
     {
         Output::verbose("database {$config['db']} has been dropped");


### PR DESCRIPTION
Как ты и просил сделал пулл риквест.

Бага собственно в том, что для того, чтобы сравнить текущую базу с записаной схемой тулза разворачивает временную базу и не всегда соблюдает порядок запросов. Соответсвенно при наличии внешних ключей таблицы со ссылками на пока еще не созданые таблицы фейлятся и падают в миграцию как созданные и удаленные.

Отключение проверки ключей на момент создания базы - помогает.
