### PR TITLE
Add primary key to version table

### DIFF
--- a/lib/Helper.class.php
+++ b/lib/Helper.class.php
@@ -166,7 +166,7 @@ class Helper
     $tbl = self::get('versiontable');
     $rev = self::getCurrentVersion();
     $db->query("DROP TABLE IF EXISTS `{$tbl}`");
-    $db->query("CREATE TABLE `{$tbl}` (`rev` BIGINT(20) UNSIGNED) ENGINE=MyISAM");
+    $db->query("CREATE TABLE `{$tbl}` (`rev` BIGINT(20) UNSIGNED, PRIMARY KEY(`rev`)) ENGINE=MyISAM");
     $db->query("TRUNCATE `{$tbl}`");
     $db->query("INSERT INTO `{$tbl}` VALUES({$rev})");
   }


### PR DESCRIPTION
Add primary key to revision table.

Such key has following advantages:
1) Speedup while applying new migrations
2) Help tools that rely on primary keys (such as MySQL workbench)

This change is compatible with the old revision table structure, it only affects new schemas.