### PR TITLE
Changed DIR_SEP to DIRECTORY_SEPARATOR

### DIFF
--- a/migration.php
+++ b/migration.php
@@ -6,7 +6,7 @@ $cli_params = Helper::parseCommandLineArgs($argv);
 
 if(empty($cli_params['options']['config']))
 {
-  $cli_params['options']['config'] = __DIR__ . DIR_SEP . 'config.ini';
+  $cli_params['options']['config'] = __DIR__ . DIRECTORY_SEPARATOR . 'config.ini';
 }
 $config = array();
 if(file_exists($cli_params['options']['config']))


### PR DESCRIPTION
DIR_SEP should either be defined (it is not by default; at least not on PHP 5.6.10), or DIRECTORY_SEPARATOR should be used.