### PR TITLE
make sure echo-cmd is visible in terminal by sending outputbuffer

### DIFF
--- a/lib/initController.class.php
+++ b/lib/initController.class.php
@@ -29,6 +29,7 @@ class initController extends AbstractController
 '
             ) {
                 echo 'Can I rewrite tables in database (all data will be lost) [y/n]? ';
+                ob_flush();
             }
             $c = fread(STDIN, 1);
             if ($c === 'Y' or $c === 'y') {


### PR DESCRIPTION
Using idler/MPP within a cli-route of [slim-framwork](http://www.slimframework.com/) does not show any output. so the script is waiting for user-input but the user does not see the message `Can I rewrite tables in database (all data will be lost) [y/n]?`

a simple `ob_flush()` after the `echo` did the trick.
